### PR TITLE
dae-installer: user can override $MACHINE variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,12 @@ If you have difficulty accessing GitHub, you can use this command instead:
 sudo sh -c "$(wget -qO- https://cdn.jsdelivr.net/gh/daeuniverse/dae-installer/installer.sh)" @ install use-cdn
 ```
 
+If this script recognizes the wrong `$MACHINE`, you can manually specify it:
+
+```sh
+sudo MACHINE="x86_64" sh -c "$(wget -qO- https://github.com/daeuniverse/dae-installer/raw/main/installer.sh)" @ install
+```
+
 ### Uninstall dae
 
 ```sh

--- a/installer.sh
+++ b/installer.sh
@@ -208,6 +208,9 @@ compare_version(){
 
 check_arch() {
 if [ "$(uname)" = 'Linux' ]; then
+    if [ -n "$MACHINE" ]; then
+        return
+    fi
 case "$(uname -m)" in
       'i386' | 'i686')
         MACHINE='x86_32'


### PR DESCRIPTION
For some CPUs, the `MACHINE` variable recognized by the script may cause the downloaded dae binary not to run properly, we can avoid this by enabling the user to specify this variable.

Example:
```text
processor       : 0
vendor_id       : AuthenticAMD
cpu family      : 18
model           : 1
model name      : AMD A6-3420M APU with Radeon(tm) HD Graphics
stepping        : 0
microcode       : 0x3000027
cpu MHz         : 800.000
cache size      : 1024 KB
physical id     : 0
siblings        : 4
core id         : 0
cpu cores       : 4
apicid          : 0
initial apicid  : 0
fpu             : yes
fpu_exception   : yes
cpuid level     : 6
wp              : yes
flags           : fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush mmx fxsr sse sse2 ht syscall nx mmxext fxsr_opt pdpe1gb rdtscp lm 3dnowext 3dnow constant_tsc rep_good nopl nonstop_tsc cpuid extd_apicid aperfmperf pni monitor cx16 popcnt lahf_lm cmp_legacy extapic cr8_legacy abm sse4a misalignsse 3dnowprefetch osvw ibs skinit wdt cpb hw_pstate vmmcall arat npt lbrv svm_lock nrip_save pausefilter
bugs            : fxsave_leak sysret_ss_attrs null_seg spectre_v1 spectre_v2
bogomips        : 2994.60
TLB size        : 1536 4K pages
clflush size    : 64
cache_alignment : 64
address sizes   : 40 bits physical, 48 bits virtual
power management: ts ttp tm stc 100mhzsteps hwpstate cpb
```

If you run the script directly, the `MACHINE` variable will be recognized as `x86_64-v2` but actually the CPU doesn't support v2, so the downloaded dae won't run properly.

```shell
sudo MACHINE="x86_64" sh -c "$(wget -qO- https://github.com/daeuniverse/dae-installer/raw/main/installer.sh)" @ install
```
Now we can override `MACHINE` variable to force the script to download corrected binary